### PR TITLE
Fix MemoryRead numeric parsing: accept 0x size values and enforce strict parsing

### DIFF
--- a/src/MCPx64dbg.cpp
+++ b/src/MCPx64dbg.cpp
@@ -39,6 +39,7 @@
 #include <memory>
 #include <fstream>
 #include <cctype>
+#include <limits>
 // Link with ws2_32.lib
 #pragma comment(lib, "ws2_32.lib")
 
@@ -90,6 +91,8 @@ void parseHttpRequest(const std::string& request, std::string& method, std::stri
 std::unordered_map<std::string, std::string> parseQueryParams(const std::string& query);
 std::string urlDecode(const std::string& str);
 std::string escapeJsonString(const char* str);
+bool parseHexDuint(const std::string& input, duint& out);
+bool parseAutoDuint(const std::string& input, duint& out);
 
 // Command callback declarations
 bool cbEnableHttpServer(int argc, char* argv[]);
@@ -243,6 +246,49 @@ std::string escapeJsonString(const char* str) {
         str++;
     }
     return result;
+}
+
+static std::string trimAscii(const std::string& input) {
+    size_t start = input.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos) {
+        return "";
+    }
+    size_t end = input.find_last_not_of(" \t\r\n");
+    return input.substr(start, end - start + 1);
+}
+
+static bool parseDuintWithBase(const std::string& input, int base, duint& out) {
+    std::string token = trimAscii(input);
+    if (token.empty()) {
+        return false;
+    }
+
+    try {
+        size_t pos = 0;
+        unsigned long long value = std::stoull(token, &pos, base);
+        if (pos != token.size()) {
+            return false;
+        }
+        if (value > static_cast<unsigned long long>((std::numeric_limits<duint>::max)())) {
+            return false;
+        }
+        out = static_cast<duint>(value);
+        return true;
+    } catch (const std::exception&) {
+        return false;
+    }
+}
+
+bool parseHexDuint(const std::string& input, duint& out) {
+    std::string token = trimAscii(input);
+    if (token.size() >= 2 && token[0] == '0' && (token[1] == 'x' || token[1] == 'X')) {
+        token = token.substr(2);
+    }
+    return parseDuintWithBase(token, 16, out);
+}
+
+bool parseAutoDuint(const std::string& input, duint& out) {
+    return parseDuintWithBase(input, 0, out);
 }
 
 // HTTP server thread function using standard Winsock
@@ -584,14 +630,7 @@ DWORD WINAPI HttpServerThread(LPVOID lpParam) {
                     
                     duint addr = 0;
                     duint size = 0;
-                    try {
-                        if (addrStr.substr(0, 2) == "0x") {
-                            addr = std::stoull(addrStr.substr(2), nullptr, 16);
-                        } else {
-                            addr = std::stoull(addrStr, nullptr, 16);
-                        }
-                        size = std::stoull(sizeStr, nullptr, 10);
-                    } catch (const std::exception& e) {
+                    if (!parseHexDuint(addrStr, addr) || !parseAutoDuint(sizeStr, size)) {
                         sendHttpResponse(clientSocket, 400, "text/plain", "Invalid address or size format");
                         continue;
                     }
@@ -626,13 +665,7 @@ DWORD WINAPI HttpServerThread(LPVOID lpParam) {
                     }
                     
                     duint addr = 0;
-                    try {
-                        if (addrStr.substr(0, 2) == "0x") {
-                            addr = std::stoull(addrStr.substr(2), nullptr, 16);
-                        } else {
-                            addr = std::stoull(addrStr, nullptr, 16);
-                        }
-                    } catch (const std::exception& e) {
+                    if (!parseHexDuint(addrStr, addr)) {
                         sendHttpResponse(clientSocket, 400, "text/plain", "Invalid address format");
                         continue;
                     }
@@ -663,13 +696,7 @@ DWORD WINAPI HttpServerThread(LPVOID lpParam) {
                     }
                     
                     duint addr = 0;
-                    try {
-                        if (addrStr.substr(0, 2) == "0x") {
-                            addr = std::stoull(addrStr.substr(2), nullptr, 16);
-                        } else {
-                            addr = std::stoull(addrStr, nullptr, 16);
-                        }
-                    } catch (const std::exception& e) {
+                    if (!parseHexDuint(addrStr, addr)) {
                         sendHttpResponse(clientSocket, 400, "text/plain", "Invalid address format");
                         continue;
                     }
@@ -685,13 +712,7 @@ DWORD WINAPI HttpServerThread(LPVOID lpParam) {
                     }
                     
                     duint addr = 0;
-                    try {
-                        if (addrStr.substr(0, 2) == "0x") {
-                            addr = std::stoull(addrStr.substr(2), nullptr, 16);
-                        } else {
-                            addr = std::stoull(addrStr, nullptr, 16);
-                        }
-                    } catch (const std::exception& e) {
+                    if (!parseHexDuint(addrStr, addr)) {
                         sendHttpResponse(clientSocket, 400, "text/plain", "Invalid address format");
                         continue;
                     }

--- a/src/x64dbg.py
+++ b/src/x64dbg.py
@@ -283,8 +283,8 @@ def MemoryRead(addr: str, size: str) -> str:
     Read memory using enhanced Script API
     
     Parameters:
-        addr: Memory address (in hex format, e.g. "0x1000")
-        size: Number of bytes to read
+        addr: Memory address in hex, with or without "0x" prefix (e.g. "0x1000" or "1000")
+        size: Number of bytes to read (decimal or "0x" prefixed hex)
     
     Returns:
         Hexadecimal string representing the memory contents


### PR DESCRIPTION
 ## Summary

  - Fix strict numeric parsing in src/MCPx64dbg.cpp for memory endpoints.
  - Make MemoryRead.size accept both decimal and 0x-prefixed hex values.
  - Prevent partial numeric parse bugs (example: "0x100" being interpreted as 0 under base-10 parse).
  - Reuse shared parsing for related memory endpoints (Memory/Read, Memory/Write, Memory/IsValidPtr, Memory/GetProtect).
  - Update MemoryRead docs in src/x64dbg.py to reflect accepted formats.

  ## Root Cause

  Memory/Read parsed size with base-10 std::stoull(sizeStr, nullptr, 10).
  For input like "0x100", parsing consumed only the leading 0 and returned 0 without throwing, which later surfaced as misleading 500 Failed to read memory.

  ## Validation

  - Built plugin successfully for both architectures:
      - MCPx64dbg.dp32
      - MCPx64dbg.dp64
  - Live-tested behavior in x64dbg/MCP:
      - MemoryRead(addr=<valid>, size="256") succeeds.
      - MemoryRead(addr=<valid>, size="0x100") now also succeeds.
      - Malformed numeric inputs (e.g. "0x100x") now return 400 Invalid address or size format.