### PR TITLE
fix: support MCP SDK 2.x FastMCP rename

### DIFF
--- a/src/x64dbg.py
+++ b/src/x64dbg.py
@@ -5,7 +5,11 @@ import json
 from typing import Any, Callable, Dict, List, Optional
 import requests
 
-from mcp.server.fastmcp import FastMCP
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError:
+    # MCP SDK >= 2.0 renamed FastMCP to MCPServer
+    from mcp.server.mcpserver import MCPServer as FastMCP
 
 DEFAULT_X64DBG_SERVER = "http://127.0.0.1:8888/"
 


### PR DESCRIPTION
MCP SDK 2.0 removed mcp.server.fastmcp and renamed FastMCP to MCPServer under mcp.server.mcpserver, so the import failed on Python installs with the 2.x SDK and the server exited before the stdio handshake.

Fall back to MCPServer when the 1.x path is unavailable. The class is API-compatible with the surface used here — the constructor's name argument, @mcp.tool(), and mcp.run() — so all 56 tool registrations work unchanged on both SDK versions.